### PR TITLE
Allow authorised client filter to delete tokens.

### DIFF
--- a/src/main/java/uk/ac/ox/ctl/oauth2/client/annotation/RegisteredOAuth2AuthorizedClient.java
+++ b/src/main/java/uk/ac/ox/ctl/oauth2/client/annotation/RegisteredOAuth2AuthorizedClient.java
@@ -69,4 +69,10 @@ public @interface RegisteredOAuth2AuthorizedClient {
    * @return if the parameter is required.
    */
   boolean required() default true;
+
+  /**
+   * Set if the existing authorized client should be deleted so we get another one.
+   * @return if any existing authorized client should be deleted.
+   */
+  boolean renew() default false;
 }


### PR DESCRIPTION
A controller can specify that it wants the argument resolver to delete the existing authorisation and user has request that they grant access again. This is useful if you need the user to re-authorise because something has changed.